### PR TITLE
Wrap sudo_users in a string

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -8,7 +8,7 @@
     owner=root
     group=root
     mode=0440
-  with_items: sudo_users
+  with_items: "{{ sudo_users }}"
   tags:
     - system
     - sudo


### PR DESCRIPTION
Ansible complains about a missing variable without this

> fatal: [172.30.43.0]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'name'\n\nThe error appears to have been in '/Users/jonathan/.ansible/roles/michaeld.sudoers/tasks/config.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Adding users\n  ^ here\n"}

> → ansible --version
> ansible 2.7.5
>   config file = None
>   configured module search path = ['/Users/jonathan/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
>   ansible python module location = /usr/local/Cellar/ansible/2.7.5/libexec/lib/python3.7/site-packages/ansible
>   executable location = /usr/local/bin/ansible
>   python version = 3.7.2 (default, Dec 27 2018, 07:35:52) [Clang 10.0.0 (clang-1000.11.45.5)]